### PR TITLE
fix: improve TD generation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ fn main() -> Result<()> {
         .finish_extend()
         .id(format!("shtc3/{device_id:#02x}"))
         .description("Example Thing exposing a shtc3 sensor")
+        .security(|builder| builder.no_sec().required().with_key("nosec_sc"))
         .property("temperature", |p| {
             p.finish_extend_data_schema()
                 .attype("TemperatureProperty")

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
     // Build the thing description
     let td = Thing::builder("shtc3")
         .finish_extend()
-        .id(format!("shtc3/{device_id:#02x}"))
+        .id(format!("urn:shtc3/{device_id:#02x}"))
         .description("Example Thing exposing a shtc3 sensor")
         .security(|builder| builder.no_sec().required().with_key("nosec_sc"))
         .property("temperature", |p| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,10 +66,14 @@ fn main() -> Result<()> {
 
     println!("Device ID SHTC3: {:#02x}", device_id);
 
+    let base_ip_address = _wifi.sta_netif().get_ip_info()?.ip;
+    let base_uri = format!("http://{}", base_ip_address);
+
     // Build the thing description
     let td = Thing::builder("shtc3")
         .finish_extend()
         .id(format!("urn:shtc3/{device_id:#02x}"))
+        .base(base_uri)
         .description("Example Thing exposing a shtc3 sensor")
         .security(|builder| builder.no_sec().required().with_key("nosec_sc"))
         .property("temperature", |p| {


### PR DESCRIPTION
Hi there :)

While adopting the example for a different sensor, I noticed that there a few things where the TD that is generated could be improved. The two most important aspects I've noticed were a missing `base` URI as well as an empty `security` array, which rendered the TD invalid when consuming it from another device. I hope that this PR provides appropriate fixes in these two areas :)

A third, rather optional thing I've noticed was that the `id` could or even should be turned into a URN. However, the format might be a bit debatable here and could also be dropped or moved to another PR instead.