### PR TITLE
feat: add support for DNS-SD via mDNS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ shtcx        = "0.11.0"
 toml-cfg     = "0.1.3"
 wot-td = "0.3.1"
 
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/mdns", version = "1.2" }
+
 [build-dependencies]
 embuild  = "0.31.4"
 toml-cfg = "0.1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use esp_idf_svc::{
         prelude::*,
     },
     http::server::{Configuration, EspHttpServer},
+    mdns::EspMdns,
 };
 use shtcx::{self, shtc3, PowerMode};
 use std::{
@@ -159,6 +160,21 @@ fn main() -> Result<()> {
             Ok(())
         },
     )?;
+
+    let mut mdns = EspMdns::take().unwrap();
+    mdns.set_hostname("shtc3-thing").unwrap();
+    mdns.add_service(
+        Some("shtc3"),
+        "_wot",
+        "_tcp",
+        80,
+        &[
+            ("td", "/.well-known/wot"),
+            ("type", "Thing"),
+            ("scheme", "http"),
+        ],
+    )
+    .unwrap();
 
     println!("Server awaiting connection");
 


### PR DESCRIPTION
This PR adds support for discovery via mDNS to the application using espressif's own mDNS component for esp-idf.

As I am working with Xtensa-based ESP32 boards, I have only been able to test this out in my adopted version of this example and not with a RISC-V ESP32, so before merging, it might be best if you try to run it locally first :) 